### PR TITLE
.gitignore: ignore .vscode files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ git-src
 .project
 .cproject
 .ccache
-.vscode
+.vscode*


### PR DESCRIPTION
`.vscode-ctags` files are being tracked by git.  Update to include any .vscode file
